### PR TITLE
#163689394 Ft(navigation): App page navigation

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -28,6 +28,15 @@
         <pair source="c" header="h" fileNamingConvention="NONE" />
       </extensions>
     </Objective-C-extensions>
+    <codeStyleSettings language="XML">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+        <option name="USE_TAB_CHARACTER" value="true" />
+        <option name="SMART_TABS" value="true" />
+      </indentOptions>
+    </codeStyleSettings>
     <codeStyleSettings language="kotlin">
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </codeStyleSettings>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,7 +5,7 @@
     <option name="myDefaultNotNull" value="android.support.annotation.NonNull" />
     <option name="myNullables">
       <value>
-        <list size="7">
+        <list size="10">
           <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.Nullable" />
           <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nullable" />
           <item index="2" class="java.lang.String" itemvalue="javax.annotation.CheckForNull" />
@@ -13,18 +13,24 @@
           <item index="4" class="java.lang.String" itemvalue="android.support.annotation.Nullable" />
           <item index="5" class="java.lang.String" itemvalue="androidx.annotation.Nullable" />
           <item index="6" class="java.lang.String" itemvalue="androidx.annotation.RecentlyNullable" />
+          <item index="7" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.Nullable" />
+          <item index="8" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableDecl" />
+          <item index="9" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableType" />
         </list>
       </value>
     </option>
     <option name="myNotNulls">
       <value>
-        <list size="6">
+        <list size="9">
           <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.NotNull" />
           <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nonnull" />
           <item index="2" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.NonNull" />
           <item index="3" class="java.lang.String" itemvalue="android.support.annotation.NonNull" />
           <item index="4" class="java.lang.String" itemvalue="androidx.annotation.NonNull" />
           <item index="5" class="java.lang.String" itemvalue="androidx.annotation.RecentlyNonNull" />
+          <item index="6" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.NonNull" />
+          <item index="7" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullDecl" />
+          <item index="8" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullType" />
         </list>
       </value>
     </option>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,6 +6,8 @@ apply plugin: 'kotlin-kapt'
 
 apply plugin: 'kotlin-android-extensions'
 
+apply plugin: 'androidx.navigation.safeargs'
+
 android {
     compileSdkVersion 28
     defaultConfig {
@@ -30,19 +32,36 @@ android {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.android.support:appcompat-v7:$support_version"
-    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
-    implementation "com.android.support:design:$support_version"
-    implementation "com.android.support:cardview-v7:$support_version"
-    implementation "com.android.support:support-v4:$support_version"
+    implementation 'androidx.appcompat:appcompat:1.1.0-alpha01'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-alpha3'
+    implementation 'androidx.core:core-ktx:1.0.1'
+    implementation 'com.google.android.material:material:1.1.0-alpha03'
+    implementation 'androidx.cardview:cardview:1.0.0'
+    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
 
     // Testing Libraries
+    implementation 'com.google.android.material:material:1.1.0-alpha03'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.0'
     androidTestImplementation 'androidx.test:rules:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
     implementation 'org.mockito:mockito-core:2.23.0'
     testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0'
+
+    // Navigation
+    implementation "android.arch.navigation:navigation-fragment-ktx:$nav_version"
+    implementation "android.arch.navigation:navigation-ui-ktx:$nav_version"
+    implementation "android.arch.navigation:navigation-fragment:$nav_version"
+    implementation "android.arch.navigation:navigation-ui:$nav_version"
+
+    //Gson
+    implementation 'com.google.code.gson:gson:2.8.5'
+
+    // DateTime support
+    implementation 'com.jakewharton.threetenabp:threetenabp:1.1.0'
+
+    // Material Design
+    implementation 'com.google.android.material:material:1.0.0'
 
     // Logger
     implementation 'com.jakewharton.timber:timber:4.7.1'
@@ -70,12 +89,12 @@ dependencies {
     androidTestImplementation "org.koin:koin-test:$koin_version"
 
     // ViewModel and LiveData
-    implementation 'android.arch.lifecycle:extensions:1.1.1'
-    kapt "android.arch.lifecycle:compiler:1.1.1"
+    implementation 'androidx.lifecycle:lifecycle-extensions:2.1.0-alpha02'
+    kapt "androidx.lifecycle:lifecycle-compiler:2.1.0-alpha02"
 
     // Room
-    implementation "android.arch.persistence.room:runtime:$room_version"
-    kapt "android.arch.persistence.room:compiler:$room_version"
-    implementation "android.arch.persistence.room:rxjava2:$room_version"
-    testImplementation "android.arch.persistence.room:testing:$room_version"
+    implementation 'androidx.room:room-runtime:2.1.0-alpha04'
+    kapt 'androidx.room:room-compiler:2.1.0-alpha04'
+    implementation 'androidx.room:room-rxjava2:2.1.0-alpha04'
+    testImplementation 'androidx.room:room-testing:2.1.0-alpha04'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,16 +1,30 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools"
-          package="com.hyman.newsapp">
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+		xmlns:android="http://schemas.android.com/apk/res/android"
+		xmlns:tools="http://schemas.android.com/tools"
+		package="com.hyman.newsapp">
 
-    <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+	<uses-permission android:name="android.permission.INTERNET"/>
+	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
-    <application
-            android:name=".NewsApplication"
-            android:allowBackup="true"
-            android:label="@string/app_name"
-            android:icon="@mipmap/ic_launcher"
-            android:roundIcon="@mipmap/ic_launcher_round"
-            android:supportsRtl="true"
-            android:theme="@style/AppTheme"
-            tools:ignore="GoogleAppIndexingWarning"/>
+	<application
+			android:name=".NewsApplication"
+			android:allowBackup="true"
+			android:icon="@mipmap/ic_launcher"
+			android:label="@string/app_name"
+			android:roundIcon="@mipmap/ic_launcher_round"
+			android:supportsRtl="true"
+			android:theme="@style/AppTheme"
+			tools:ignore="GoogleAppIndexingWarning">
+		<activity
+				android:name=".views.NewsActivity"
+				android:label="@string/title_activity_news">
+			<intent-filter>
+				<action android:name="android.intent.action.MAIN"/>
+
+				<category android:name="android.intent.category.LAUNCHER"/>
+			</intent-filter>
+		</activity>
+	</application>
+
 </manifest>

--- a/app/src/main/java/com/hyman/newsapp/domain/baseViews/BaseActivity.kt
+++ b/app/src/main/java/com/hyman/newsapp/domain/baseViews/BaseActivity.kt
@@ -1,10 +1,10 @@
 package com.hyman.newsapp.domain.baseViews
 
-import android.databinding.DataBindingUtil
-import android.databinding.ViewDataBinding
+import androidx.databinding.DataBindingUtil
+import androidx.databinding.ViewDataBinding
 import android.os.Bundle
-import android.support.annotation.LayoutRes
-import android.support.v7.app.AppCompatActivity
+import androidx.annotation.LayoutRes
+import androidx.appcompat.app.AppCompatActivity
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.disposables.Disposable
 
@@ -33,5 +33,4 @@ abstract class BaseActivity<T : ViewDataBinding>: AppCompatActivity() {
         compositeDisposable?.clear()
         compositeDisposable = null
     }
-
 }

--- a/app/src/main/java/com/hyman/newsapp/domain/baseViews/BaseFragment.kt
+++ b/app/src/main/java/com/hyman/newsapp/domain/baseViews/BaseFragment.kt
@@ -1,10 +1,10 @@
 package com.hyman.newsapp.domain.baseViews
 
-import android.databinding.DataBindingUtil
-import android.databinding.ViewDataBinding
+import androidx.databinding.DataBindingUtil
+import androidx.databinding.ViewDataBinding
 import android.os.Bundle
-import android.support.annotation.LayoutRes
-import android.support.v4.app.Fragment
+import androidx.annotation.LayoutRes
+import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup

--- a/app/src/main/java/com/hyman/newsapp/domain/bindingAdapter/BindAdapters.kt
+++ b/app/src/main/java/com/hyman/newsapp/domain/bindingAdapter/BindAdapters.kt
@@ -1,6 +1,6 @@
 package com.hyman.newsapp.domain.bindingAdapter
 
-import android.databinding.BindingAdapter
+import androidx.databinding.BindingAdapter
 import android.view.View
 
 @BindingAdapter("isVisible")

--- a/app/src/main/java/com/hyman/newsapp/domain/extentions/ViewExtentions.kt
+++ b/app/src/main/java/com/hyman/newsapp/domain/extentions/ViewExtentions.kt
@@ -1,8 +1,8 @@
 package com.hyman.newsapp.domain.extentions
 
-import android.support.design.widget.Snackbar
-import android.support.v4.app.Fragment
-import android.support.v7.app.AppCompatActivity
+import com.google.android.material.snackbar.Snackbar
+import androidx.fragment.app.Fragment
+import androidx.appcompat.app.AppCompatActivity
 import android.view.View
 import com.hyman.newsapp.util.isConnectedToNetwork
 

--- a/app/src/main/java/com/hyman/newsapp/views/FoodNewsFragment.kt
+++ b/app/src/main/java/com/hyman/newsapp/views/FoodNewsFragment.kt
@@ -1,0 +1,20 @@
+package com.hyman.newsapp.views
+
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+
+import com.hyman.newsapp.R
+
+class FoodNewsFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_food_news, container, false)
+    }
+}

--- a/app/src/main/java/com/hyman/newsapp/views/HomeNewsFragment.kt
+++ b/app/src/main/java/com/hyman/newsapp/views/HomeNewsFragment.kt
@@ -1,0 +1,25 @@
+package com.hyman.newsapp.views
+
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+
+import com.hyman.newsapp.R
+
+
+class HomeNewsFragment : Fragment() {
+
+    companion object {
+        fun newInstance() = HomeNewsFragment()
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_home_news, container, false)
+    }
+}

--- a/app/src/main/java/com/hyman/newsapp/views/NewsActivity.kt
+++ b/app/src/main/java/com/hyman/newsapp/views/NewsActivity.kt
@@ -1,0 +1,30 @@
+package com.hyman.newsapp.views
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.navigation.NavController
+import androidx.navigation.Navigation
+import androidx.navigation.ui.NavigationUI
+import androidx.navigation.ui.setupWithNavController
+import com.hyman.newsapp.R
+import kotlinx.android.synthetic.main.activity_news.*
+
+class NewsActivity : AppCompatActivity() {
+    private lateinit var navController: NavController
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_news)
+
+        setSupportActionBar(tb_app_toolbar)
+
+        navController = Navigation.findNavController(this, R.id.fragment_nav_host)
+        bn_navigation.setupWithNavController(navController)
+
+        NavigationUI.setupActionBarWithNavController(this, navController)
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        return NavigationUI.navigateUp(navController, null)
+    }
+}

--- a/app/src/main/java/com/hyman/newsapp/views/TravelNewsFragment.kt
+++ b/app/src/main/java/com/hyman/newsapp/views/TravelNewsFragment.kt
@@ -1,0 +1,20 @@
+package com.hyman.newsapp.views
+
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+
+import com.hyman.newsapp.R
+
+class TravelNewsFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_travel_news, container, false)
+    }
+}

--- a/app/src/main/res/drawable/ic_food.xml
+++ b/app/src/main/res/drawable/ic_food.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M8.1,13.34l2.83,-2.83L3.91,3.5c-1.56,1.56 -1.56,4.09 0,5.66l4.19,4.18zM14.88,11.53c1.53,0.71 3.68,0.21 5.27,-1.38 1.91,-1.91 2.28,-4.65 0.81,-6.12 -1.46,-1.46 -4.2,-1.1 -6.12,0.81 -1.59,1.59 -2.09,3.74 -1.38,5.27L3.7,19.87l1.41,1.41L12,14.41l6.88,6.88 1.41,-1.41L13.41,13l1.47,-1.47z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_home.xml
+++ b/app/src/main/res/drawable/ic_home.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+            android:fillColor="#FF000000"
+            android:pathData="M10,20v-6h4v6h5v-8h3L12,3 2,12h3v8z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_travel.xml
+++ b/app/src/main/res/drawable/ic_travel.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M10.18,9"/>
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M21,16v-2l-8,-5V3.5c0,-0.83 -0.67,-1.5 -1.5,-1.5S10,2.67 10,3.5V9l-8,5v2l8,-2.5V19l-2,1.5V22l3.5,-1 3.5,1v-1.5L13,19v-5.5l8,2.5z"/>
+</vector>

--- a/app/src/main/res/layout/activity_news.xml
+++ b/app/src/main/res/layout/activity_news.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+		xmlns:android="http://schemas.android.com/apk/res/android"
+		xmlns:app="http://schemas.android.com/apk/res-auto"
+		xmlns:tools="http://schemas.android.com/tools"
+		android:id="@+id/container"
+		android:layout_width="match_parent"
+		android:layout_height="match_parent"
+		tools:context=".views.NewsActivity">
+
+	<androidx.appcompat.widget.Toolbar
+			android:id="@+id/tb_app_toolbar"
+			android:layout_width="match_parent"
+			android:layout_height="?attr/actionBarSize"
+			android:background="?colorPrimary"
+			android:theme="@style/ToolbarTheme"
+			tools:ignore="MissingConstraints"/>
+
+	<fragment
+			android:id="@+id/fragment_nav_host"
+			android:layout_width="match_parent"
+			android:layout_height="0dp"
+			app:layout_constraintTop_toBottomOf="@id/tb_app_toolbar"
+			app:layout_constraintBottom_toTopOf="@id/bn_navigation"
+			android:name="androidx.navigation.fragment.NavHostFragment"
+			app:navGraph="@navigation/app_navigation"
+			app:defaultNavHost="true"/>
+
+	<com.google.android.material.bottomnavigation.BottomNavigationView
+			android:id="@+id/bn_navigation"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			app:layout_constraintBottom_toBottomOf="parent"
+			app:layout_constraintLeft_toLeftOf="parent"
+			app:layout_constraintRight_toRightOf="parent"
+			app:menu="@menu/bottom_navigation"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_food_news.xml
+++ b/app/src/main/res/layout/fragment_food_news.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+		xmlns:android="http://schemas.android.com/apk/res/android"
+		xmlns:tools="http://schemas.android.com/tools"
+		android:layout_width="match_parent"
+		android:layout_height="match_parent"
+		tools:context=".views.FoodNewsFragment">
+
+	<TextView
+			android:layout_width="match_parent"
+			android:layout_height="match_parent"
+			android:text="Food"/>
+
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_home_news.xml
+++ b/app/src/main/res/layout/fragment_home_news.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+		xmlns:android="http://schemas.android.com/apk/res/android"
+		xmlns:tools="http://schemas.android.com/tools"
+		android:layout_width="match_parent"
+		android:layout_height="match_parent"
+		tools:context=".views.HomeNewsFragment">
+
+	<TextView
+			android:layout_width="match_parent"
+			android:layout_height="match_parent"
+			android:text="home"/>
+
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_travel_news.xml
+++ b/app/src/main/res/layout/fragment_travel_news.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+		xmlns:android="http://schemas.android.com/apk/res/android"
+		xmlns:tools="http://schemas.android.com/tools"
+		android:layout_width="match_parent"
+		android:layout_height="match_parent"
+		tools:context=".views.TravelNewsFragment">
+
+	<TextView
+			android:layout_width="match_parent"
+			android:layout_height="match_parent"
+			android:text="Travel"/>
+
+</FrameLayout>

--- a/app/src/main/res/menu/bottom_navigation.xml
+++ b/app/src/main/res/menu/bottom_navigation.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+	<item
+			android:id="@+id/home_news_fragment"
+			android:icon="@drawable/ic_home"
+			android:title="@string/title_home"/>
+
+	<item
+			android:id="@+id/food_news_fragment"
+			android:icon="@drawable/ic_food"
+			android:title="@string/title_food"/>
+
+	<item
+			android:id="@+id/travel_news_fragment"
+			android:icon="@drawable/ic_travel"
+			android:title="@string/title_travel"/>
+</menu>

--- a/app/src/main/res/navigation/app_navigation.xml
+++ b/app/src/main/res/navigation/app_navigation.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation
+		xmlns:android="http://schemas.android.com/apk/res/android"
+		xmlns:app="http://schemas.android.com/apk/res-auto"
+		xmlns:tools="http://schemas.android.com/tools"
+		android:id="@+id/app_navigation.xml"
+		app:startDestination="@id/home_news_fragment">
+
+	<fragment
+			android:id="@+id/home_news_fragment"
+			android:name="com.hyman.newsapp.views.HomeNewsFragment"
+			android:label="Home"
+			tools:layout="@layout/fragment_home_news"/>
+	<fragment
+			android:id="@+id/food_news_fragment"
+			android:name="com.hyman.newsapp.views.FoodNewsFragment"
+			android:label="Food"
+			tools:layout="@layout/fragment_food_news"/>
+	<fragment
+			android:id="@+id/travel_news_fragment"
+			android:name="com.hyman.newsapp.views.TravelNewsFragment"
+			android:label="Travel"
+			tools:layout="@layout/fragment_travel_news"/>
+</navigation>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,5 @@
+<resources>
+    <!-- Default screen margins, per the Android Design guidelines. -->
+    <dimen name="activity_horizontal_margin">16dp</dimen>
+    <dimen name="activity_vertical_margin">16dp</dimen>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,7 @@
 <resources>
     <string name="app_name">NewsApp</string>
+    <string name="title_activity_news">NewsActivity</string>
+    <string name="title_home">Home</string>
+    <string name="title_food">Food</string>
+    <string name="title_travel">Travel</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,11 +1,19 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AppTheme" parent="Theme.MaterialComponents.Light.DarkActionBar">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
+        <!--Removing actionbar-->
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+    </style>
+
+    <style name="ToolbarTheme" parent="ThemeOverlay.MaterialComponents.ActionBar">
+        <item name="android:textColorPrimary">@android:color/white</item>
+        <item name="android:textColorSecondary">#EEEEEE</item>
     </style>
 
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -3,17 +3,19 @@
 buildscript {
     ext.rx_java_version = '2.2.0'
     ext.rx_android_version = '1.2.1'
-    ext.kotlin_version = '1.3.11'
+    ext.kotlin_version = '1.3.20'
     ext.room_version = '1.1.1'
     ext.support_version = '28.0.0'
     ext.koin_version = '1.0.2'
+    ext.nav_version = "1.0.0-alpha11"
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath 'com.android.tools.build:gradle:3.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "android.arch.navigation:navigation-safe-args-gradle-plugin:$nav_version"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,3 +13,5 @@ org.gradle.jvmargs=-Xmx1536m
 # org.gradle.parallel=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+android.useAndroidX=true
+android.enableJetifier=true


### PR DESCRIPTION
### What does this PR do?
- Setup basic page navigation

### Description of Task to be completed?
- [x] add home, food and travel fragments used as basic navigation pages
- [x] add entry activity housing all fragments
- [x] setup page navigation functionality using Navigation Controller
- [x] upgrade app dependencies to AndriodX

### How should this be manually tested?
```
- Clone this repo
- Open and build the project on an android studio
- Launch the application
```
Any background context you want to provide?
There are three(3) basic navigation pages:
- Home
- Food
- Travel

### What are the relevant pivotal tracker stories?
story type: feature
story Id: 163689394
story titles: User can navigate between pages

### Screenshots (if appropriate)
![screenshot 2019-02-07 at 4 37 54 pm](https://user-images.githubusercontent.com/22524619/52422656-c8c22980-2af6-11e9-93c6-c43587055def.png)



