### PR TITLE
#163798964 Ft(retrofit): Setup http operations using retrofit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,9 @@ jobs:
         key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
     - *license_agreement
     - run:
+        name: Store API Key
+        command: echo $API_SECRET | base64 --decode >> /home/circleci/code/app/src/main/java/com/hyman/newsapp/util/ApiSecretKey.kt
+    - run:
         name: Download Dependencies
         command: |
           sudo chmod +x gradlew

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ fastlane/test_output
 fastlane/readme.md
 
 .DS_Store
+app/src/main/java/com/hyman/newsapp/util/ApiSecretKey.kt

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,6 +17,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        buildConfigField "String", "BASE_URL", "\"https://api.nytimes.com/svc/topstories/v2/\""
     }
     buildTypes {
         release {
@@ -51,8 +52,6 @@ dependencies {
     // Navigation
     implementation "android.arch.navigation:navigation-fragment-ktx:$nav_version"
     implementation "android.arch.navigation:navigation-ui-ktx:$nav_version"
-    implementation "android.arch.navigation:navigation-fragment:$nav_version"
-    implementation "android.arch.navigation:navigation-ui:$nav_version"
 
     //Gson
     implementation 'com.google.code.gson:gson:2.8.5'

--- a/app/src/main/java/com/hyman/newsapp/Globals/Constants.kt
+++ b/app/src/main/java/com/hyman/newsapp/Globals/Constants.kt
@@ -1,0 +1,7 @@
+package com.hyman.newsapp.Globals
+
+object Constants {
+    enum class NewsType {
+        HOME, FOOD, TRAVEL
+    }
+}

--- a/app/src/main/java/com/hyman/newsapp/domain/data/api/ApiService.kt
+++ b/app/src/main/java/com/hyman/newsapp/domain/data/api/ApiService.kt
@@ -1,0 +1,16 @@
+package com.hyman.newsapp.domain.data.api
+
+import com.hyman.newsapp.views.models.NewsResponse
+import io.reactivex.Observable
+import retrofit2.http.GET
+
+interface ApiService {
+    @GET("home.json")
+    fun getHomeNews(): Observable<NewsResponse>
+
+    @GET("food.json")
+    fun getFoodNews(): Observable<NewsResponse>
+
+    @GET("travel.json")
+    fun getTravelNews(): Observable<NewsResponse>
+}

--- a/app/src/main/java/com/hyman/newsapp/domain/data/api/IRetrofitModule.kt
+++ b/app/src/main/java/com/hyman/newsapp/domain/data/api/IRetrofitModule.kt
@@ -1,0 +1,7 @@
+package com.hyman.newsapp.domain.data.api
+
+import retrofit2.Retrofit
+
+interface IRetrofitModule {
+    fun getRetrofit(): Retrofit
+}

--- a/app/src/main/java/com/hyman/newsapp/domain/data/api/RetrofitModule.kt
+++ b/app/src/main/java/com/hyman/newsapp/domain/data/api/RetrofitModule.kt
@@ -1,0 +1,46 @@
+package com.hyman.newsapp.domain.data.api
+
+import com.hyman.newsapp.util.ApiSecret.KEY
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
+import retrofit2.converter.gson.GsonConverterFactory
+import java.util.concurrent.TimeUnit
+
+class RetrofitModule(private val baseUrl: String) : IRetrofitModule {
+    private val loggingInterceptor = HttpLoggingInterceptor().apply {
+        level = HttpLoggingInterceptor.Level.BODY
+    }
+
+    private val requestInterceptor: Interceptor = Interceptor { chain ->
+        val baseRequest = chain.request()
+        val url = baseRequest.url()
+            .newBuilder()
+            .addQueryParameter("api-key", KEY)
+            .build()
+
+        chain.proceed(
+            baseRequest.newBuilder()
+                .url(url)
+                .build()
+        )
+    }
+
+    private val okHttpClient: OkHttpClient = OkHttpClient.Builder()
+        .addInterceptor(requestInterceptor)
+        .addInterceptor(loggingInterceptor)
+        .connectTimeout(30, TimeUnit.SECONDS)
+        .readTimeout(30, TimeUnit.SECONDS)
+        .build()
+
+    override fun getRetrofit(): Retrofit {
+        return Retrofit.Builder()
+            .baseUrl(baseUrl)
+            .client(okHttpClient)
+            .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+    }
+}

--- a/app/src/main/java/com/hyman/newsapp/domain/data/repository/abstractions/IOnlineRepository.kt
+++ b/app/src/main/java/com/hyman/newsapp/domain/data/repository/abstractions/IOnlineRepository.kt
@@ -1,0 +1,9 @@
+package com.hyman.newsapp.domain.data.repository.abstractions
+
+import com.hyman.newsapp.Globals.Constants
+import com.hyman.newsapp.views.models.NewsResponse
+import io.reactivex.Observable
+
+interface IOnlineRepository {
+    fun getNews(newsType : Constants.NewsType) : Observable<NewsResponse>
+}

--- a/app/src/main/java/com/hyman/newsapp/domain/data/repository/abstractions/IRepository.kt
+++ b/app/src/main/java/com/hyman/newsapp/domain/data/repository/abstractions/IRepository.kt
@@ -1,0 +1,9 @@
+package com.hyman.newsapp.domain.data.repository.abstractions
+
+import com.hyman.newsapp.Globals.Constants
+import com.hyman.newsapp.views.models.NewsResponse
+import io.reactivex.Observable
+
+interface IRepository {
+    fun getNews(newsType : Constants.NewsType) : Observable<NewsResponse>
+}

--- a/app/src/main/java/com/hyman/newsapp/domain/data/repository/implementations/OnlineRepository.kt
+++ b/app/src/main/java/com/hyman/newsapp/domain/data/repository/implementations/OnlineRepository.kt
@@ -1,0 +1,21 @@
+package com.hyman.newsapp.domain.data.repository.implementations
+
+import com.hyman.newsapp.Globals.Constants
+import com.hyman.newsapp.domain.data.api.ApiService
+import com.hyman.newsapp.domain.data.api.IRetrofitModule
+import com.hyman.newsapp.domain.data.repository.abstractions.IOnlineRepository
+import com.hyman.newsapp.views.models.NewsResponse
+import io.reactivex.Observable
+
+class OnlineRepository(retrofitModule: IRetrofitModule) : IOnlineRepository{
+    private val retrofit = retrofitModule.getRetrofit()
+    private val apiService = retrofit.create(ApiService::class.java)
+
+    override fun getNews(newsType: Constants.NewsType): Observable<NewsResponse> {
+        return when(newsType) {
+            Constants.NewsType.HOME -> apiService.getHomeNews()
+            Constants.NewsType.FOOD -> apiService.getFoodNews()
+            Constants.NewsType.TRAVEL -> apiService.getTravelNews()
+        }
+    }
+}

--- a/app/src/main/java/com/hyman/newsapp/domain/data/repository/implementations/Repository.kt
+++ b/app/src/main/java/com/hyman/newsapp/domain/data/repository/implementations/Repository.kt
@@ -1,0 +1,13 @@
+package com.hyman.newsapp.domain.data.repository.implementations
+
+import com.hyman.newsapp.Globals.Constants
+import com.hyman.newsapp.domain.data.repository.abstractions.IOnlineRepository
+import com.hyman.newsapp.domain.data.repository.abstractions.IRepository
+import com.hyman.newsapp.views.models.NewsResponse
+import io.reactivex.Observable
+
+class Repository(private val onlineRepository: IOnlineRepository) : IRepository {
+    override fun getNews(newsType: Constants.NewsType): Observable<NewsResponse> {
+        return onlineRepository.getNews(newsType)
+    }
+}

--- a/app/src/main/java/com/hyman/newsapp/domain/di/AppModules.kt
+++ b/app/src/main/java/com/hyman/newsapp/domain/di/AppModules.kt
@@ -1,7 +1,21 @@
 package com.hyman.newsapp.domain.di
 
+import com.hyman.newsapp.BuildConfig
+import com.hyman.newsapp.domain.data.api.IRetrofitModule
+import com.hyman.newsapp.domain.data.api.RetrofitModule
+import com.hyman.newsapp.domain.data.repository.abstractions.IOnlineRepository
+import com.hyman.newsapp.domain.data.repository.abstractions.IRepository
+import com.hyman.newsapp.domain.data.repository.implementations.OnlineRepository
+import com.hyman.newsapp.domain.data.repository.implementations.Repository
+import com.hyman.newsapp.views.NewsViewModel
+import org.koin.android.viewmodel.ext.koin.viewModel
 import org.koin.dsl.module.Module
 import org.koin.dsl.module.module
 
 val appModule: Module = module {
+    single { RetrofitModule(BuildConfig.BASE_URL) as IRetrofitModule }
+    single { OnlineRepository(get()) as IOnlineRepository }
+    single { Repository(get()) as IRepository }
+
+    viewModel { NewsViewModel(get()) }
 }

--- a/app/src/main/java/com/hyman/newsapp/views/NewsActivity.kt
+++ b/app/src/main/java/com/hyman/newsapp/views/NewsActivity.kt
@@ -6,11 +6,19 @@ import androidx.navigation.NavController
 import androidx.navigation.Navigation
 import androidx.navigation.ui.NavigationUI
 import androidx.navigation.ui.setupWithNavController
+import com.hyman.newsapp.Globals.Constants
 import com.hyman.newsapp.R
+import com.hyman.newsapp.domain.extentions.addToCompositeDisposable
+import com.hyman.newsapp.domain.extentions.executeOnBackground
+import io.reactivex.disposables.CompositeDisposable
 import kotlinx.android.synthetic.main.activity_news.*
+import org.koin.android.viewmodel.ext.android.viewModel
+import timber.log.Timber
 
 class NewsActivity : AppCompatActivity() {
     private lateinit var navController: NavController
+    private val viewModel: NewsViewModel by viewModel()
+    private val compositeDisposable = CompositeDisposable()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -21,7 +29,20 @@ class NewsActivity : AppCompatActivity() {
         navController = Navigation.findNavController(this, R.id.fragment_nav_host)
         bn_navigation.setupWithNavController(navController)
 
+        getNewItems(Constants.NewsType.FOOD)
+
         NavigationUI.setupActionBarWithNavController(this, navController)
+    }
+
+    private fun getNewItems(food: Constants.NewsType) {
+        viewModel.getNewFromApi(food)
+            .executeOnBackground()
+            .subscribe({
+                Timber.e("NEWS RESPONSE: ${it.news.size}")
+            }, {
+                Timber.e("ERROR: ${it.message}")
+            })
+            .addToCompositeDisposable(compositeDisposable)
     }
 
     override fun onSupportNavigateUp(): Boolean {

--- a/app/src/main/java/com/hyman/newsapp/views/NewsViewModel.kt
+++ b/app/src/main/java/com/hyman/newsapp/views/NewsViewModel.kt
@@ -1,0 +1,21 @@
+package com.hyman.newsapp.views
+
+import androidx.lifecycle.ViewModel
+import com.hyman.newsapp.Globals.Constants
+import com.hyman.newsapp.domain.data.repository.abstractions.IRepository
+import com.hyman.newsapp.views.models.NewsResponse
+import io.reactivex.Observable
+import timber.log.Timber
+
+class NewsViewModel(private val repository: IRepository) : ViewModel() {
+
+    fun getNewFromApi(newsType: Constants.NewsType): Observable<NewsResponse> {
+        return repository.getNews(newsType)
+            .flatMap {
+                Observable.just(it)
+            }
+            .doOnError {
+                Timber.e("ERROR: ${it.message}")
+            }
+    }
+}

--- a/app/src/main/java/com/hyman/newsapp/views/models/Multimedia.kt
+++ b/app/src/main/java/com/hyman/newsapp/views/models/Multimedia.kt
@@ -1,0 +1,8 @@
+package com.hyman.newsapp.views.models
+
+data class Multimedia(
+    val caption: String,
+    val copyright: String,
+    val format: String,
+    val url: String
+)

--- a/app/src/main/java/com/hyman/newsapp/views/models/NewsResponse.kt
+++ b/app/src/main/java/com/hyman/newsapp/views/models/NewsResponse.kt
@@ -1,0 +1,7 @@
+package com.hyman.newsapp.views.models
+
+import com.google.gson.annotations.SerializedName
+
+data class NewsResponse(
+    @SerializedName("results") val news: List<Result>
+)

--- a/app/src/main/java/com/hyman/newsapp/views/models/Result.kt
+++ b/app/src/main/java/com/hyman/newsapp/views/models/Result.kt
@@ -1,0 +1,14 @@
+package com.hyman.newsapp.views.models
+
+import com.google.gson.annotations.SerializedName
+
+data class Result(
+    val abstract: String,
+    @SerializedName("byline") val author: String,
+    val multimedia: List<Multimedia>,
+    @SerializedName("published_date")
+    val publishedDate: String,
+    @SerializedName("short_url")
+    val shortUrl: String,
+    val title: String
+)

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.room_version = '1.1.1'
     ext.support_version = '28.0.0'
     ext.koin_version = '1.0.2'
-    ext.nav_version = "1.0.0-alpha11"
+    ext.nav_version = "1.0.0-beta01"
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
### What does this PR do?
- Setup API HTTP connection with Retrofit

### Description of Task to be completed?
- [x] configure retrofit
- [x] add HTTP interceptors
- [x] add API service interface
- [x] setup online repository interface and implementation classes
- [x] add model classes
- [x] setup dependency injection
- [x] test app for response

### How should this be manually tested?
```
- Clone this repo
- Open and build the project on an android studio
- Launch the application
- Check your logcat to see the response
```
Any background context you want to provide?
Nil
### What are the relevant pivotal tracker stories?
story type: feature
story Id: 163798964
story titles: Set up retrofit for http  network service operations

### Screenshots (if appropriate)
Nil



