### PR TITLE
#164055854 Ft(offline-data): Setup up room database for offline viewing

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -96,4 +96,7 @@ dependencies {
     kapt 'androidx.room:room-compiler:2.1.0-alpha04'
     implementation 'androidx.room:room-rxjava2:2.1.0-alpha04'
     testImplementation 'androidx.room:room-testing:2.1.0-alpha04'
+
+    // For viewing local database
+    implementation 'com.facebook.stetho:stetho:1.5.0'
 }

--- a/app/src/main/java/com/hyman/newsapp/Globals/Constants.kt
+++ b/app/src/main/java/com/hyman/newsapp/Globals/Constants.kt
@@ -1,7 +1,0 @@
-package com.hyman.newsapp.Globals
-
-object Constants {
-    enum class NewsType {
-        HOME, FOOD, TRAVEL
-    }
-}

--- a/app/src/main/java/com/hyman/newsapp/NewsApplication.kt
+++ b/app/src/main/java/com/hyman/newsapp/NewsApplication.kt
@@ -2,6 +2,7 @@ package com.hyman.newsapp
 
 import android.app.Application
 import com.facebook.drawee.backends.pipeline.Fresco
+import com.facebook.stetho.Stetho
 import com.hyman.newsapp.domain.di.appModule
 import org.koin.android.ext.android.startKoin
 import timber.log.Timber
@@ -14,5 +15,6 @@ class NewsApplication : Application() {
         }
         startKoin(this, listOf(appModule))
         Fresco.initialize(this)
+        Stetho.initializeWithDefaults(this)
     }
 }

--- a/app/src/main/java/com/hyman/newsapp/domain/data/api/ApiService.kt
+++ b/app/src/main/java/com/hyman/newsapp/domain/data/api/ApiService.kt
@@ -1,16 +1,16 @@
 package com.hyman.newsapp.domain.data.api
 
 import com.hyman.newsapp.views.models.NewsResponse
-import io.reactivex.Observable
+import io.reactivex.Flowable
 import retrofit2.http.GET
 
 interface ApiService {
     @GET("home.json")
-    fun getHomeNews(): Observable<NewsResponse>
+    fun getHomeNews(): Flowable<NewsResponse>
 
     @GET("food.json")
-    fun getFoodNews(): Observable<NewsResponse>
+    fun getFoodNews(): Flowable<NewsResponse>
 
     @GET("travel.json")
-    fun getTravelNews(): Observable<NewsResponse>
+    fun getTravelNews(): Flowable<NewsResponse>
 }

--- a/app/src/main/java/com/hyman/newsapp/domain/data/db/NewsDao.kt
+++ b/app/src/main/java/com/hyman/newsapp/domain/data/db/NewsDao.kt
@@ -1,0 +1,21 @@
+package com.hyman.newsapp.domain.data.db
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy.REPLACE
+import androidx.room.Query
+import com.hyman.newsapp.globals.Constants.RESPONSE_TABLE_NAME
+import com.hyman.newsapp.views.models.NewsResponse
+import io.reactivex.Flowable
+
+@Dao
+interface NewsDao {
+    @Insert(onConflict = REPLACE)
+    fun insertNewsResponse(response: NewsResponse)
+
+    @Query("SELECT * FROM $RESPONSE_TABLE_NAME WHERE section=:type")
+    fun getNewsByType(type: String): Flowable<NewsResponse>
+
+    @Query("DELETE FROM $RESPONSE_TABLE_NAME WHERE section=:type")
+    fun clearNews(type: String)
+}

--- a/app/src/main/java/com/hyman/newsapp/domain/data/db/NewsDatabase.kt
+++ b/app/src/main/java/com/hyman/newsapp/domain/data/db/NewsDatabase.kt
@@ -1,0 +1,14 @@
+package com.hyman.newsapp.domain.data.db
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+import com.hyman.newsapp.domain.data.db.typeconverters.MultimediaConverter
+import com.hyman.newsapp.domain.data.db.typeconverters.NewsConverter
+import com.hyman.newsapp.views.models.NewsResponse
+
+@Database(entities = [NewsResponse::class], version = 1)
+@TypeConverters(NewsConverter::class, MultimediaConverter::class)
+abstract class NewsDatabase : RoomDatabase() {
+    abstract fun newsDao(): NewsDao
+}

--- a/app/src/main/java/com/hyman/newsapp/domain/data/db/typeconverters/MultimediaConverter.kt
+++ b/app/src/main/java/com/hyman/newsapp/domain/data/db/typeconverters/MultimediaConverter.kt
@@ -1,0 +1,27 @@
+package com.hyman.newsapp.domain.data.db.typeconverters
+
+import androidx.room.TypeConverter
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.hyman.newsapp.views.models.Multimedia
+import java.util.*
+
+class MultimediaConverter {
+    private val gson = Gson()
+
+    @TypeConverter
+    fun stringToMediaList(dataString: String?): List<Multimedia> {
+        if (dataString == null) {
+            return Collections.emptyList()
+        }
+
+        val listType = object : TypeToken<List<Multimedia>>() {}.type
+
+        return gson.fromJson(dataString, listType)
+    }
+
+    @TypeConverter
+    fun mediaListToString(dataObject: List<Multimedia>): String {
+        return gson.toJson(dataObject)
+    }
+}

--- a/app/src/main/java/com/hyman/newsapp/domain/data/db/typeconverters/NewsConverter.kt
+++ b/app/src/main/java/com/hyman/newsapp/domain/data/db/typeconverters/NewsConverter.kt
@@ -1,0 +1,27 @@
+package com.hyman.newsapp.domain.data.db.typeconverters
+
+import androidx.room.TypeConverter
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.hyman.newsapp.views.models.News
+import java.util.*
+
+class NewsConverter {
+    private val gson = Gson()
+
+    @TypeConverter
+    fun stringToNewsList(dataString: String?): List<News> {
+        if (dataString == null) {
+            return Collections.emptyList()
+        }
+
+        val listType = object : TypeToken<List<News>>() {}.type
+
+        return gson.fromJson(dataString, listType)
+    }
+
+    @TypeConverter
+    fun newsListToString(dataObject: List<News>): String {
+        return gson.toJson(dataObject)
+    }
+}

--- a/app/src/main/java/com/hyman/newsapp/domain/data/repository/abstractions/IOfflineRepository.kt
+++ b/app/src/main/java/com/hyman/newsapp/domain/data/repository/abstractions/IOfflineRepository.kt
@@ -4,6 +4,8 @@ import com.hyman.newsapp.globals.Constants
 import com.hyman.newsapp.views.models.NewsResponse
 import io.reactivex.Flowable
 
-interface IOnlineRepository {
-    fun getOnlineNews(newsType: Constants.NewsType): Flowable<NewsResponse>
+interface IOfflineRepository {
+    fun saveNews(newsResponse: NewsResponse)
+
+    fun getOfflineNews(newsType: Constants.NewsType): Flowable<NewsResponse>
 }

--- a/app/src/main/java/com/hyman/newsapp/domain/data/repository/abstractions/IRepository.kt
+++ b/app/src/main/java/com/hyman/newsapp/domain/data/repository/abstractions/IRepository.kt
@@ -1,9 +1,9 @@
 package com.hyman.newsapp.domain.data.repository.abstractions
 
-import com.hyman.newsapp.Globals.Constants
+import com.hyman.newsapp.globals.Constants
 import com.hyman.newsapp.views.models.NewsResponse
-import io.reactivex.Observable
+import io.reactivex.Flowable
 
 interface IRepository {
-    fun getNews(newsType : Constants.NewsType) : Observable<NewsResponse>
+    fun getNews(newsType: Constants.NewsType): Flowable<NewsResponse>
 }

--- a/app/src/main/java/com/hyman/newsapp/domain/data/repository/implementations/OfflineRepository.kt
+++ b/app/src/main/java/com/hyman/newsapp/domain/data/repository/implementations/OfflineRepository.kt
@@ -1,0 +1,20 @@
+package com.hyman.newsapp.domain.data.repository.implementations
+
+import com.hyman.newsapp.globals.Constants
+import com.hyman.newsapp.domain.data.db.NewsDatabase
+import com.hyman.newsapp.domain.data.repository.abstractions.IOfflineRepository
+import com.hyman.newsapp.views.models.NewsResponse
+
+class OfflineRepository(database: NewsDatabase) : IOfflineRepository {
+    private val newsDao = database.newsDao()
+
+    override fun saveNews(newsResponse: NewsResponse) {
+        with(newsDao) {
+            clearNews(newsResponse.section)
+            insertNewsResponse(newsResponse)
+        }
+    }
+
+    override fun getOfflineNews(newsType: Constants.NewsType) =
+        newsDao.getNewsByType(newsType.toString().toLowerCase())
+}

--- a/app/src/main/java/com/hyman/newsapp/domain/data/repository/implementations/OnlineRepository.kt
+++ b/app/src/main/java/com/hyman/newsapp/domain/data/repository/implementations/OnlineRepository.kt
@@ -1,18 +1,18 @@
 package com.hyman.newsapp.domain.data.repository.implementations
 
-import com.hyman.newsapp.Globals.Constants
 import com.hyman.newsapp.domain.data.api.ApiService
 import com.hyman.newsapp.domain.data.api.IRetrofitModule
 import com.hyman.newsapp.domain.data.repository.abstractions.IOnlineRepository
+import com.hyman.newsapp.globals.Constants
 import com.hyman.newsapp.views.models.NewsResponse
-import io.reactivex.Observable
+import io.reactivex.Flowable
 
-class OnlineRepository(retrofitModule: IRetrofitModule) : IOnlineRepository{
+class OnlineRepository(retrofitModule: IRetrofitModule) : IOnlineRepository {
     private val retrofit = retrofitModule.getRetrofit()
     private val apiService = retrofit.create(ApiService::class.java)
 
-    override fun getNews(newsType: Constants.NewsType): Observable<NewsResponse> {
-        return when(newsType) {
+    override fun getOnlineNews(newsType: Constants.NewsType): Flowable<NewsResponse> {
+        return when (newsType) {
             Constants.NewsType.HOME -> apiService.getHomeNews()
             Constants.NewsType.FOOD -> apiService.getFoodNews()
             Constants.NewsType.TRAVEL -> apiService.getTravelNews()

--- a/app/src/main/java/com/hyman/newsapp/domain/data/repository/implementations/Repository.kt
+++ b/app/src/main/java/com/hyman/newsapp/domain/data/repository/implementations/Repository.kt
@@ -1,13 +1,29 @@
 package com.hyman.newsapp.domain.data.repository.implementations
 
-import com.hyman.newsapp.Globals.Constants
+import com.hyman.newsapp.domain.data.repository.abstractions.IOfflineRepository
 import com.hyman.newsapp.domain.data.repository.abstractions.IOnlineRepository
 import com.hyman.newsapp.domain.data.repository.abstractions.IRepository
+import com.hyman.newsapp.globals.Constants
 import com.hyman.newsapp.views.models.NewsResponse
-import io.reactivex.Observable
+import io.reactivex.Flowable
 
-class Repository(private val onlineRepository: IOnlineRepository) : IRepository {
-    override fun getNews(newsType: Constants.NewsType): Observable<NewsResponse> {
-        return onlineRepository.getNews(newsType)
+class Repository(private val offlineRepository: IOfflineRepository, private val onlineRepository: IOnlineRepository) :
+    IRepository {
+    override fun getNews(newsType: Constants.NewsType): Flowable<NewsResponse> {
+        return Flowable.concatArrayEager(
+            offlineRepository.getOfflineNews(newsType)
+                .filter {
+                    it.news.isNotEmpty()
+                },
+            onlineRepository.getOnlineNews(newsType)
+                .materialize()
+                .filter {
+                    !it.isOnError
+                }
+                .dematerialize<NewsResponse>()
+                .doOnNext {
+                    offlineRepository.saveNews(it)
+                }
+        )
     }
 }

--- a/app/src/main/java/com/hyman/newsapp/domain/di/AppModules.kt
+++ b/app/src/main/java/com/hyman/newsapp/domain/di/AppModules.kt
@@ -1,21 +1,35 @@
 package com.hyman.newsapp.domain.di
 
+import androidx.room.Room
 import com.hyman.newsapp.BuildConfig
 import com.hyman.newsapp.domain.data.api.IRetrofitModule
 import com.hyman.newsapp.domain.data.api.RetrofitModule
+import com.hyman.newsapp.domain.data.db.NewsDatabase
+import com.hyman.newsapp.domain.data.repository.abstractions.IOfflineRepository
 import com.hyman.newsapp.domain.data.repository.abstractions.IOnlineRepository
 import com.hyman.newsapp.domain.data.repository.abstractions.IRepository
+import com.hyman.newsapp.domain.data.repository.implementations.OfflineRepository
 import com.hyman.newsapp.domain.data.repository.implementations.OnlineRepository
 import com.hyman.newsapp.domain.data.repository.implementations.Repository
+import com.hyman.newsapp.globals.Constants.DATABASE_NAME
 import com.hyman.newsapp.views.NewsViewModel
 import org.koin.android.viewmodel.ext.koin.viewModel
 import org.koin.dsl.module.Module
 import org.koin.dsl.module.module
 
 val appModule: Module = module {
+    single {
+        Room.databaseBuilder(
+            get(),
+            NewsDatabase::class.java, DATABASE_NAME
+        )
+            .fallbackToDestructiveMigration()
+            .build()
+    }
     single { RetrofitModule(BuildConfig.BASE_URL) as IRetrofitModule }
+    single { OfflineRepository(get()) as IOfflineRepository }
     single { OnlineRepository(get()) as IOnlineRepository }
-    single { Repository(get()) as IRepository }
+    single { Repository(get(), get()) as IRepository }
 
     viewModel { NewsViewModel(get()) }
 }

--- a/app/src/main/java/com/hyman/newsapp/domain/extentions/RxExtensions.kt
+++ b/app/src/main/java/com/hyman/newsapp/domain/extentions/RxExtensions.kt
@@ -1,12 +1,12 @@
 package com.hyman.newsapp.domain.extentions
 
-import io.reactivex.Observable
+import io.reactivex.Flowable
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.disposables.Disposable
 import io.reactivex.schedulers.Schedulers
 
-fun <T> Observable<T>.executeOnBackground(): Observable<T> {
+fun <T> Flowable<T>.executeOnBackground(): Flowable<T> {
     return this.subscribeOn(Schedulers.io())
         .observeOn(AndroidSchedulers.mainThread())
 }

--- a/app/src/main/java/com/hyman/newsapp/globals/Constants.kt
+++ b/app/src/main/java/com/hyman/newsapp/globals/Constants.kt
@@ -1,0 +1,11 @@
+package com.hyman.newsapp.globals
+
+object Constants {
+    enum class NewsType {
+        HOME, FOOD, TRAVEL
+    }
+
+    const val RESPONSE_TABLE_NAME = "response"
+    const val DATABASE_NAME = "news.db"
+    const val DEBOUNCE_TIME = 500L
+}

--- a/app/src/main/java/com/hyman/newsapp/views/FoodNewsFragment.kt
+++ b/app/src/main/java/com/hyman/newsapp/views/FoodNewsFragment.kt
@@ -3,8 +3,6 @@ package com.hyman.newsapp.views
 
 import android.os.Bundle
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.hyman.newsapp.Globals.Constants
-
 import com.hyman.newsapp.R
 import com.hyman.newsapp.databinding.FragmentNewsBinding
 import com.hyman.newsapp.domain.baseViews.BaseFragment
@@ -12,6 +10,7 @@ import com.hyman.newsapp.domain.extentions.addToCompositeDisposable
 import com.hyman.newsapp.domain.extentions.executeOnBackground
 import com.hyman.newsapp.domain.extentions.isNetworkConnected
 import com.hyman.newsapp.domain.extentions.showSnackBar
+import com.hyman.newsapp.globals.Constants
 import org.koin.android.viewmodel.ext.android.viewModel
 
 class FoodNewsFragment : BaseFragment<FragmentNewsBinding>() {
@@ -34,9 +33,10 @@ class FoodNewsFragment : BaseFragment<FragmentNewsBinding>() {
     }
 
     private fun getFoodNews(newType: Constants.NewsType) {
-        viewModel.getNewFromApi(newType)
+        viewModel.getNews(newType)
             .executeOnBackground()
             .subscribe({
+                viewModel.progressIsVisible.set(false)
                 (binding.rvNewsList.adapter as NewsAdapter).updateNewsList(it.news.toMutableList())
             }, {
                 showSnackBar(
@@ -46,7 +46,6 @@ class FoodNewsFragment : BaseFragment<FragmentNewsBinding>() {
                         it.message!!,
                     getString(R.string.retry)
                 ) { getFoodNews(newType) }
-            })
-            .addToCompositeDisposable(compositeDisposable!!)
+            }).addToCompositeDisposable(compositeDisposable!!)
     }
 }

--- a/app/src/main/java/com/hyman/newsapp/views/HomeNewsFragment.kt
+++ b/app/src/main/java/com/hyman/newsapp/views/HomeNewsFragment.kt
@@ -3,15 +3,14 @@ package com.hyman.newsapp.views
 
 import android.os.Bundle
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.hyman.newsapp.Globals.Constants
 import com.hyman.newsapp.R
-
 import com.hyman.newsapp.databinding.FragmentNewsBinding
 import com.hyman.newsapp.domain.baseViews.BaseFragment
 import com.hyman.newsapp.domain.extentions.addToCompositeDisposable
 import com.hyman.newsapp.domain.extentions.executeOnBackground
 import com.hyman.newsapp.domain.extentions.isNetworkConnected
 import com.hyman.newsapp.domain.extentions.showSnackBar
+import com.hyman.newsapp.globals.Constants
 import org.koin.android.viewmodel.ext.android.viewModel
 
 class HomeNewsFragment : BaseFragment<FragmentNewsBinding>() {
@@ -34,9 +33,10 @@ class HomeNewsFragment : BaseFragment<FragmentNewsBinding>() {
     }
 
     private fun getHomeNews(newType: Constants.NewsType) {
-        viewModel.getNewFromApi(newType)
+        viewModel.getNews(newType)
             .executeOnBackground()
             .subscribe({
+                viewModel.progressIsVisible.set(false)
                 (binding.rvNewsList.adapter as NewsAdapter).updateNewsList(it.news.toMutableList())
             }, {
                 showSnackBar(
@@ -46,7 +46,6 @@ class HomeNewsFragment : BaseFragment<FragmentNewsBinding>() {
                         it.message!!,
                     getString(R.string.retry)
                 ) { getHomeNews(newType) }
-            })
-            .addToCompositeDisposable(compositeDisposable!!)
+            }).addToCompositeDisposable(compositeDisposable!!)
     }
 }

--- a/app/src/main/java/com/hyman/newsapp/views/NewsAdapter.kt
+++ b/app/src/main/java/com/hyman/newsapp/views/NewsAdapter.kt
@@ -35,6 +35,7 @@ class NewsAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
         if (position == 0) ViewType.HEADER_ITEM.num else ViewType.CONTENT_LIST_ITEM.num
 
     fun updateNewsList(news: MutableList<News>) {
+        newsList.clear()
         newsList.addAll(news)
         notifyDataSetChanged()
     }

--- a/app/src/main/java/com/hyman/newsapp/views/TravelNewsFragment.kt
+++ b/app/src/main/java/com/hyman/newsapp/views/TravelNewsFragment.kt
@@ -3,8 +3,6 @@ package com.hyman.newsapp.views
 
 import android.os.Bundle
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.hyman.newsapp.Globals.Constants
-
 import com.hyman.newsapp.R
 import com.hyman.newsapp.databinding.FragmentNewsBinding
 import com.hyman.newsapp.domain.baseViews.BaseFragment
@@ -12,6 +10,7 @@ import com.hyman.newsapp.domain.extentions.addToCompositeDisposable
 import com.hyman.newsapp.domain.extentions.executeOnBackground
 import com.hyman.newsapp.domain.extentions.isNetworkConnected
 import com.hyman.newsapp.domain.extentions.showSnackBar
+import com.hyman.newsapp.globals.Constants
 import org.koin.android.viewmodel.ext.android.viewModel
 
 class TravelNewsFragment : BaseFragment<FragmentNewsBinding>() {
@@ -34,9 +33,10 @@ class TravelNewsFragment : BaseFragment<FragmentNewsBinding>() {
     }
 
     private fun getTravelNews(newType: Constants.NewsType) {
-        viewModel.getNewFromApi(newType)
+        viewModel.getNews(newType)
             .executeOnBackground()
             .subscribe({
+                viewModel.progressIsVisible.set(false)
                 (binding.rvNewsList.adapter as NewsAdapter).updateNewsList(it.news.toMutableList())
             }, {
                 showSnackBar(
@@ -46,7 +46,6 @@ class TravelNewsFragment : BaseFragment<FragmentNewsBinding>() {
                         it.message!!,
                     getString(R.string.retry)
                 ) { getTravelNews(newType) }
-            })
-            .addToCompositeDisposable(compositeDisposable!!)
+            }).addToCompositeDisposable(compositeDisposable!!)
     }
 }

--- a/app/src/main/java/com/hyman/newsapp/views/models/News.kt
+++ b/app/src/main/java/com/hyman/newsapp/views/models/News.kt
@@ -4,11 +4,17 @@ import com.google.gson.annotations.SerializedName
 
 data class News(
     val abstract: String,
-    @SerializedName("byline") val author: String,
+
+    @SerializedName("byline")
+    val author: String,
+
     val multimedia: List<Multimedia>,
+
     @SerializedName("published_date")
     val publishedDate: String,
+
     @SerializedName("short_url")
     val shortUrl: String,
+
     val title: String
 )

--- a/app/src/main/java/com/hyman/newsapp/views/models/NewsResponse.kt
+++ b/app/src/main/java/com/hyman/newsapp/views/models/NewsResponse.kt
@@ -1,7 +1,20 @@
 package com.hyman.newsapp.views.models
 
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
 import com.google.gson.annotations.SerializedName
+import com.hyman.newsapp.globals.Constants.RESPONSE_TABLE_NAME
 
+@Entity(tableName = RESPONSE_TABLE_NAME, indices = [Index("section")])
 data class NewsResponse(
-    @SerializedName("results") val news: List<News>
+    @PrimaryKey(autoGenerate = true)
+    val id: Int,
+
+    @ColumnInfo(name = "section")
+    val section: String,
+
+    @SerializedName("results")
+    var news: List<News>
 )

--- a/app/src/main/res/layout/view_body_item.xml
+++ b/app/src/main/res/layout/view_body_item.xml
@@ -44,7 +44,7 @@
 					android:id="@+id/iv_news_image"
 					android:layout_width="120dp"
 					android:layout_height="0dp"
-					app:imageURI="@{newsModel.multimedia[4].url}"
+					app:imageURI="@{newsModel.multimedia[3].url}"
 					app:placeholderImageScaleType="fitXY"
 					app:placeholderImage="@drawable/placeholder"
 					app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/view_header_item.xml
+++ b/app/src/main/res/layout/view_header_item.xml
@@ -19,6 +19,7 @@
 				app:layout_constraintHeight_percent=".6"
 				app:imageURI="@{newsModel.multimedia[4].url}"
 				app:placeholderImage="@drawable/placeholder"
+				app:placeholderImageScaleType="fitXY"
 				app:layout_constraintEnd_toEndOf="parent"
 				app:layout_constraintStart_toStartOf="parent"
 				app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
### What does this PR do?
- Allows users to view news offline

### Description of Task to be completed?
- [x] add offline interface and implementations
- [x] set up entity, database, dao and type converters classes for room
- [x] modify recyclerview adapter to clear data before inserting
- [x] add library for viewing database on browser
- [x] concatenate calls to offline and remote databases

### How should this be manually tested?
```
- Clone this repo
- Open and build the project on an android studio
- Launch the application
```
Any background context you want to provide?
Nil
### What are the relevant pivotal tracker stories?
story type: feature
story Id: 164055854
story titles: Set up local database

### Screenshots (if appropriate)
Nil
