### PR TITLE
ft(share): user can share news to their contacts

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,8 @@
 
 	<uses-permission android:name="android.permission.INTERNET"/>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+	<uses-permission android:name="android.permission.READ_CONTACTS"/>
+	<uses-permission android:name="android.permission.SEND_SMS"/>
 
 	<application
 			android:name=".NewsApplication"

--- a/app/src/main/java/com/hyman/newsapp/domain/baseViews/BaseFragment.kt
+++ b/app/src/main/java/com/hyman/newsapp/domain/baseViews/BaseFragment.kt
@@ -1,19 +1,36 @@
 package com.hyman.newsapp.domain.baseViews
 
+import android.Manifest
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
+import androidx.core.content.ContextCompat
 import androidx.databinding.DataBindingUtil
 import androidx.databinding.ViewDataBinding
 import androidx.fragment.app.Fragment
+import com.hyman.newsapp.R
+import com.hyman.newsapp.domain.extentions.showSnackBar
+import com.hyman.newsapp.globals.Constants
+import com.hyman.newsapp.views.NewsAdapter
+import com.hyman.newsapp.views.NewsViewModel
+import com.hyman.newsapp.views.contactprovider.ContactDialogFragment
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.disposables.Disposable
+import org.koin.android.viewmodel.ext.android.viewModel
+
 
 abstract class BaseFragment<B : ViewDataBinding> : Fragment() {
     var compositeDisposable: CompositeDisposable? = null
     protected lateinit var binding: B
+
+    val viewModel: NewsViewModel by viewModel()
+
+    private var newsUrl: String? = null
 
     @LayoutRes
     protected abstract fun layoutId(): Int
@@ -24,7 +41,63 @@ abstract class BaseFragment<B : ViewDataBinding> : Fragment() {
         return binding.root
     }
 
+    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        if (requestCode == Constants.REQUEST_READ_CONTACTS) {
+            if ((grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED)) {
+                displayContactsDialog()
+            } else {
+                showSnackBar("You need to allow contacts access permission to share a news")
+            }
+        }
+    }
+
     fun bind(disposable: Disposable) = compositeDisposable?.add(disposable)
+
+    private fun requestContactAccessPermission() {
+        val permission = Manifest.permission.READ_CONTACTS
+
+        if (ContextCompat.checkSelfPermission(context!!, permission) != PackageManager.PERMISSION_GRANTED) {
+            requestPermissions(arrayOf(permission), Constants.REQUEST_READ_CONTACTS)
+        } else {
+            displayContactsDialog()
+        }
+    }
+
+    private fun displayContactsDialog() {
+        val args = Bundle()
+        args.putString("newsUrl", newsUrl)
+        val dialog = ContactDialogFragment.newInstance()
+
+        dialog.arguments = args
+        dialog.show(activity!!.supportFragmentManager, "contact dialog")
+    }
+
+    fun shareNewsListener(newsAdapter: NewsAdapter) {
+        newsAdapter.shareNewsItemClick = {
+            newsUrl = it.shortUrl
+            requestContactAccessPermission()
+        }
+    }
+
+    fun moreNewsListener(newsAdapter: NewsAdapter) {
+        newsAdapter.moreNewsItemClick = {
+            openFullNewsInBrowser(it)
+        }
+    }
+
+    private fun openFullNewsInBrowser(url: String) {
+        val uri = Uri.parse(url)
+        val intent = Intent(Intent.ACTION_VIEW)
+            .addCategory(Intent.CATEGORY_BROWSABLE)
+            .setData(uri)
+
+        if (intent.resolveActivity(activity!!.packageManager) != null) {
+            startActivity(intent)
+        } else {
+            showSnackBar(resources.getString(R.string.no_browser_installed))
+        }
+    }
 
     override fun onDestroy() {
         super.onDestroy()

--- a/app/src/main/java/com/hyman/newsapp/domain/data/db/NewsDatabase.kt
+++ b/app/src/main/java/com/hyman/newsapp/domain/data/db/NewsDatabase.kt
@@ -7,7 +7,7 @@ import com.hyman.newsapp.domain.data.db.typeconverters.MultimediaConverter
 import com.hyman.newsapp.domain.data.db.typeconverters.NewsConverter
 import com.hyman.newsapp.views.models.NewsResponse
 
-@Database(entities = [NewsResponse::class], version = 1)
+@Database(entities = [NewsResponse::class], version = 1, exportSchema = false)
 @TypeConverters(NewsConverter::class, MultimediaConverter::class)
 abstract class NewsDatabase : RoomDatabase() {
     abstract fun newsDao(): NewsDao

--- a/app/src/main/java/com/hyman/newsapp/domain/data/repository/implementations/OfflineRepository.kt
+++ b/app/src/main/java/com/hyman/newsapp/domain/data/repository/implementations/OfflineRepository.kt
@@ -1,8 +1,8 @@
 package com.hyman.newsapp.domain.data.repository.implementations
 
-import com.hyman.newsapp.globals.Constants
 import com.hyman.newsapp.domain.data.db.NewsDatabase
 import com.hyman.newsapp.domain.data.repository.abstractions.IOfflineRepository
+import com.hyman.newsapp.globals.Constants
 import com.hyman.newsapp.views.models.NewsResponse
 
 class OfflineRepository(database: NewsDatabase) : IOfflineRepository {

--- a/app/src/main/java/com/hyman/newsapp/domain/extentions/ViewExtentions.kt
+++ b/app/src/main/java/com/hyman/newsapp/domain/extentions/ViewExtentions.kt
@@ -1,15 +1,22 @@
 package com.hyman.newsapp.domain.extentions
 
-import com.google.android.material.snackbar.Snackbar
-import androidx.fragment.app.Fragment
-import androidx.appcompat.app.AppCompatActivity
 import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import com.google.android.material.snackbar.Snackbar
 import com.hyman.newsapp.util.isConnectedToNetwork
 
 fun Fragment.showSnackBar(message: String, actionMessage: String, action: (v: View?) -> Unit) {
     view?.let {
         Snackbar.make(it, message, Snackbar.LENGTH_INDEFINITE)
             .setAction(actionMessage, action)
+            .show()
+    }
+}
+
+fun Fragment.showSnackBar(message: String) {
+    view?.let {
+        Snackbar.make(it, message, Snackbar.LENGTH_LONG)
             .show()
     }
 }

--- a/app/src/main/java/com/hyman/newsapp/globals/Constants.kt
+++ b/app/src/main/java/com/hyman/newsapp/globals/Constants.kt
@@ -8,4 +8,5 @@ object Constants {
     const val RESPONSE_TABLE_NAME = "response"
     const val DATABASE_NAME = "news.db"
     const val DEBOUNCE_TIME = 500L
+    const val REQUEST_READ_CONTACTS = 124
 }

--- a/app/src/main/java/com/hyman/newsapp/views/FoodNewsFragment.kt
+++ b/app/src/main/java/com/hyman/newsapp/views/FoodNewsFragment.kt
@@ -11,14 +11,12 @@ import com.hyman.newsapp.domain.extentions.executeOnBackground
 import com.hyman.newsapp.domain.extentions.isNetworkConnected
 import com.hyman.newsapp.domain.extentions.showSnackBar
 import com.hyman.newsapp.globals.Constants
-import org.koin.android.viewmodel.ext.android.viewModel
 
 class FoodNewsFragment : BaseFragment<FragmentNewsBinding>() {
     override fun layoutId() = R.layout.fragment_news
-    private val viewModel: NewsViewModel by viewModel()
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
-        binding.viewModel = this@FoodNewsFragment.viewModel
+        binding.viewModel = viewModel
         initRecyclerView()
         getFoodNews(Constants.NewsType.FOOD)
         super.onActivityCreated(savedInstanceState)
@@ -32,12 +30,20 @@ class FoodNewsFragment : BaseFragment<FragmentNewsBinding>() {
         }
     }
 
+    private fun getAdapter(): NewsAdapter {
+        return (binding.rvNewsList.adapter as NewsAdapter)
+    }
+
     private fun getFoodNews(newType: Constants.NewsType) {
         viewModel.getNews(newType)
             .executeOnBackground()
             .subscribe({
                 viewModel.progressIsVisible.set(false)
-                (binding.rvNewsList.adapter as NewsAdapter).updateNewsList(it.news.toMutableList())
+                with(getAdapter()) {
+                    updateNewsList(it.news.toMutableList())
+                    shareNewsListener(this)
+                    moreNewsListener(this)
+                }
             }, {
                 showSnackBar(
                     if (!isNetworkConnected())

--- a/app/src/main/java/com/hyman/newsapp/views/HomeNewsFragment.kt
+++ b/app/src/main/java/com/hyman/newsapp/views/HomeNewsFragment.kt
@@ -1,6 +1,5 @@
 package com.hyman.newsapp.views
 
-
 import android.os.Bundle
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.hyman.newsapp.R
@@ -11,14 +10,12 @@ import com.hyman.newsapp.domain.extentions.executeOnBackground
 import com.hyman.newsapp.domain.extentions.isNetworkConnected
 import com.hyman.newsapp.domain.extentions.showSnackBar
 import com.hyman.newsapp.globals.Constants
-import org.koin.android.viewmodel.ext.android.viewModel
 
 class HomeNewsFragment : BaseFragment<FragmentNewsBinding>() {
     override fun layoutId() = R.layout.fragment_news
-    private val viewModel: NewsViewModel by viewModel()
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
-        binding.viewModel = this@HomeNewsFragment.viewModel
+        binding.viewModel = viewModel
         initRecyclerView()
         getHomeNews(Constants.NewsType.HOME)
         super.onActivityCreated(savedInstanceState)
@@ -32,12 +29,20 @@ class HomeNewsFragment : BaseFragment<FragmentNewsBinding>() {
         }
     }
 
+    private fun getAdapter(): NewsAdapter {
+        return (binding.rvNewsList.adapter as NewsAdapter)
+    }
+
     private fun getHomeNews(newType: Constants.NewsType) {
         viewModel.getNews(newType)
             .executeOnBackground()
             .subscribe({
                 viewModel.progressIsVisible.set(false)
-                (binding.rvNewsList.adapter as NewsAdapter).updateNewsList(it.news.toMutableList())
+                with(getAdapter()) {
+                    updateNewsList(it.news.toMutableList())
+                    shareNewsListener(this)
+                    moreNewsListener(this)
+                }
             }, {
                 showSnackBar(
                     if (!isNetworkConnected())

--- a/app/src/main/java/com/hyman/newsapp/views/NewsAdapter.kt
+++ b/app/src/main/java/com/hyman/newsapp/views/NewsAdapter.kt
@@ -11,6 +11,8 @@ import com.hyman.newsapp.views.models.News
 class NewsAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     lateinit var binding: ViewDataBinding
     var newsList = mutableListOf<News>()
+    var shareNewsItemClick: ((News) -> Unit)? = null
+    var moreNewsItemClick: ((String) -> Unit)? = null
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         return if (viewType == ViewType.HEADER_ITEM.num) {
@@ -49,8 +51,16 @@ class NewsAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     inner class BodyViewHolder(var binding: ViewBodyItemBinding) : RecyclerView.ViewHolder(binding.root) {
         fun bind(news: News) {
-            binding.newsModel = news
-            binding.executePendingBindings()
+            with(binding) {
+                btnReadMore.setOnClickListener {
+                    moreNewsItemClick?.invoke(news.shortUrl)
+                }
+                ivShareIcon.setOnClickListener {
+                    shareNewsItemClick?.invoke(news)
+                }
+                newsModel = news
+                executePendingBindings()
+            }
         }
     }
 

--- a/app/src/main/java/com/hyman/newsapp/views/NewsViewModel.kt
+++ b/app/src/main/java/com/hyman/newsapp/views/NewsViewModel.kt
@@ -11,6 +11,7 @@ import java.util.concurrent.TimeUnit
 
 class NewsViewModel(private val repository: IRepository) : ViewModel() {
     val progressIsVisible = ObservableBoolean(false)
+    val hasContacts = ObservableBoolean()
 
     fun getNews(newsType: Constants.NewsType): Flowable<NewsResponse> {
         progressIsVisible.set(true)

--- a/app/src/main/java/com/hyman/newsapp/views/TravelNewsFragment.kt
+++ b/app/src/main/java/com/hyman/newsapp/views/TravelNewsFragment.kt
@@ -11,11 +11,9 @@ import com.hyman.newsapp.domain.extentions.executeOnBackground
 import com.hyman.newsapp.domain.extentions.isNetworkConnected
 import com.hyman.newsapp.domain.extentions.showSnackBar
 import com.hyman.newsapp.globals.Constants
-import org.koin.android.viewmodel.ext.android.viewModel
 
 class TravelNewsFragment : BaseFragment<FragmentNewsBinding>() {
     override fun layoutId() = R.layout.fragment_news
-    private val viewModel: NewsViewModel by viewModel()
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         binding.viewModel = this@TravelNewsFragment.viewModel
@@ -32,12 +30,20 @@ class TravelNewsFragment : BaseFragment<FragmentNewsBinding>() {
         }
     }
 
+    private fun getAdapter(): NewsAdapter {
+        return (binding.rvNewsList.adapter as NewsAdapter)
+    }
+
     private fun getTravelNews(newType: Constants.NewsType) {
         viewModel.getNews(newType)
             .executeOnBackground()
             .subscribe({
                 viewModel.progressIsVisible.set(false)
-                (binding.rvNewsList.adapter as NewsAdapter).updateNewsList(it.news.toMutableList())
+                with(getAdapter()) {
+                    updateNewsList(it.news.toMutableList())
+                    shareNewsListener(this)
+                    moreNewsListener(this)
+                }
             }, {
                 showSnackBar(
                     if (!isNetworkConnected())

--- a/app/src/main/java/com/hyman/newsapp/views/contactprovider/ContactAdapter.kt
+++ b/app/src/main/java/com/hyman/newsapp/views/contactprovider/ContactAdapter.kt
@@ -1,0 +1,42 @@
+package com.hyman.newsapp.views.contactprovider
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.hyman.newsapp.databinding.ContactListItemBinding
+import com.hyman.newsapp.views.models.Contact
+
+class ContactAdapter(var contactItemClick: ((Contact) -> Unit)) : RecyclerView.Adapter<ContactAdapter.ContactViewHolder>() {
+
+    private var contacts = mutableListOf<Contact>()
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ContactViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        val binding = ContactListItemBinding.inflate(inflater, parent, false)
+        return ContactViewHolder(binding)
+    }
+
+    override fun getItemCount(): Int = contacts.size
+
+    override fun onBindViewHolder(holder: ContactViewHolder, position: Int) {
+        holder.bind(contacts[position])
+    }
+
+    inner class ContactViewHolder(val binding: ContactListItemBinding) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(contact: Contact) {
+            with(binding) {
+                cvContactCardItem.setOnClickListener {
+                    contactItemClick.invoke(contact)
+                }
+                model = contact
+                executePendingBindings()
+            }
+        }
+    }
+
+    fun updateContactList(allContacts: List<Contact>) {
+        contacts.clear()
+        contacts.addAll(allContacts)
+        notifyDataSetChanged()
+    }
+}

--- a/app/src/main/java/com/hyman/newsapp/views/contactprovider/ContactDialogFragment.kt
+++ b/app/src/main/java/com/hyman/newsapp/views/contactprovider/ContactDialogFragment.kt
@@ -1,0 +1,146 @@
+package com.hyman.newsapp.views.contactprovider
+
+import android.app.Dialog
+import android.content.ContentResolver
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.provider.ContactsContract
+import android.view.LayoutInflater
+import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.DialogFragment
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.hyman.newsapp.R
+import com.hyman.newsapp.databinding.FragmentContactBinding
+import com.hyman.newsapp.views.NewsViewModel
+import com.hyman.newsapp.views.models.Contact
+import io.reactivex.disposables.CompositeDisposable
+import org.koin.android.viewmodel.ext.android.viewModel
+
+
+class ContactDialogFragment : DialogFragment() {
+    private var compositeDisposable: CompositeDisposable? = null
+    lateinit var binding: FragmentContactBinding
+
+    private val viewModel: NewsViewModel by viewModel()
+    private val usersContactList = ArrayList<Contact>()
+    private var selectedNewsUrl: String? = null
+
+    companion object {
+        fun newInstance(): ContactDialogFragment = ContactDialogFragment()
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        selectedNewsUrl = arguments?.getString("newsUrl")
+        getUserContacts()
+        super.onCreate(savedInstanceState)
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val builder = activity?.let { AlertDialog.Builder(it) }
+        val layoutInflater: LayoutInflater = activity!!.layoutInflater
+
+        binding = FragmentContactBinding.inflate(layoutInflater, null, false)
+
+//        Timber.e("IN CONTACT DIALOG $newsUrl")
+
+        builder?.run {
+            setTitle(R.string.title_contact)
+            setView(binding.root)
+
+        }.apply {
+            return this!!.create()
+        }
+    }
+
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+        binding.viewModel = this@ContactDialogFragment.viewModel
+        initRecyclerView()
+        compositeDisposable = CompositeDisposable()
+
+        if (usersContactList.size == 0)
+            viewModel.hasContacts.set(false)
+        else {
+            viewModel.hasContacts.set(true)
+            showUserContacts(usersContactList)
+        }
+    }
+
+    private fun initRecyclerView() {
+        with(binding.rvContactList) {
+            layoutManager = LinearLayoutManager(context)
+            adapter = ContactAdapter {
+                sendMessage(it)
+            }
+        }
+    }
+
+    private fun getAdapter(): ContactAdapter {
+        return (binding.rvContactList.adapter as ContactAdapter)
+    }
+
+    private fun sendMessage(contact: Contact) {
+        val textMessage =
+            "Hi ${contact.name}, you were requested to view this news page: $selectedNewsUrl"
+
+        val i = Intent(Intent.ACTION_SEND)
+            .setData(Uri.parse("smsto:"))
+            .setType(resources.getString(R.string.share_intent_type))
+            .putExtra("address", contact.number)
+            .putExtra("sms_body", textMessage)
+        startActivity(i)
+
+    }
+
+    private fun showUserContacts(usersContactList: ArrayList<Contact>) {
+        getAdapter().updateContactList(usersContactList)
+    }
+
+    private fun getUserContacts() {
+        val resolver: ContentResolver = activity!!.contentResolver
+        val cursor = resolver.query(
+            ContactsContract.Contacts.CONTENT_URI, null,
+            null, null, null
+        )
+
+        cursor?.apply {
+            if (count > 0) {
+                while (moveToNext()) {
+                    val id = cursor.getString(cursor.getColumnIndex(ContactsContract.Contacts._ID))
+                    val name = cursor.getString(cursor.getColumnIndex(ContactsContract.Contacts.DISPLAY_NAME))
+                    val hasPhone = (cursor.getString(
+                        cursor.getColumnIndex(ContactsContract.Contacts.HAS_PHONE_NUMBER)
+                    )).toInt()
+
+                    if (hasPhone > 0) {
+                        val phoneCursor = resolver.query(
+                            ContactsContract.CommonDataKinds.Phone.CONTENT_URI,
+                            null, ContactsContract.CommonDataKinds.Phone.CONTACT_ID + "=?", arrayOf(id), null
+                        )
+
+                        phoneCursor?.apply {
+                            if (count > 0) {
+                                while (moveToNext()) {
+                                    val phoneNumber = getString(
+                                        getColumnIndex(ContactsContract.CommonDataKinds.Phone.NUMBER)
+                                    )
+
+                                    usersContactList.add(Contact(name, phoneNumber))
+                                }
+                            }
+                        }
+                        phoneCursor?.close()
+                    }
+                }
+            }
+        }
+        cursor?.close()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        compositeDisposable?.clear()
+        compositeDisposable = null
+    }
+}

--- a/app/src/main/java/com/hyman/newsapp/views/models/Contact.kt
+++ b/app/src/main/java/com/hyman/newsapp/views/models/Contact.kt
@@ -1,0 +1,6 @@
+package com.hyman.newsapp.views.models
+
+data class Contact(
+    val name: String,
+    val number: String
+)

--- a/app/src/main/res/layout/contact_list_item.xml
+++ b/app/src/main/res/layout/contact_list_item.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout
+		xmlns:android="http://schemas.android.com/apk/res/android"
+		xmlns:tools="http://schemas.android.com/tools"
+		xmlns:app="http://schemas.android.com/apk/res-auto"
+		xmlns:card_view="http://schemas.android.com/apk/res-auto">
+
+	<data>
+		<variable
+				name="model"
+				type="com.hyman.newsapp.views.models.Contact"/>
+	</data>
+
+	<androidx.cardview.widget.CardView
+			android:id="@+id/cv_contact_card_item"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:foreground="?android:attr/selectableItemBackground"
+			android:clickable="true"
+			android:focusable="true"
+			android:layout_marginBottom="5dp"
+			card_view:cardCornerRadius="10dp">
+
+		<androidx.constraintlayout.widget.ConstraintLayout
+				android:layout_width="match_parent"
+				android:layout_height="match_parent"
+				android:padding="8dp"
+				android:background="@color/contact_item_bg_color">
+
+			<TextView
+					android:id="@+id/tv_contact_name"
+					android:layout_width="match_parent"
+					android:layout_height="wrap_content"
+					tools:text="Francis maina"
+					android:text="@{model.name}"
+					android:textColor="@color/custom_gray_text"
+					android:textSize="16sp"
+					android:fontFamily="sans-serif-black"
+					app:layout_constraintTop_toTopOf="parent"
+					app:layout_constraintStart_toStartOf="parent"
+					app:layout_constraintEnd_toEndOf="parent"/>
+
+			<TextView
+					android:id="@+id/tv_contact_number"
+					android:layout_width="match_parent"
+					android:layout_height="wrap_content"
+					tools:text="0923745367"
+					android:text="@{model.number}"
+					android:textSize="16sp"
+					android:textStyle="italic"
+					android:fontFamily="sans-serif-light"
+					android:textColor="@color/custom_gray_text"
+					app:layout_constraintStart_toStartOf="parent"
+					app:layout_constraintEnd_toEndOf="parent"
+					app:layout_constraintTop_toBottomOf="@id/tv_contact_name"/>
+
+		</androidx.constraintlayout.widget.ConstraintLayout>
+
+	</androidx.cardview.widget.CardView>
+</layout>

--- a/app/src/main/res/layout/fragment_contact.xml
+++ b/app/src/main/res/layout/fragment_contact.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout
+		xmlns:android="http://schemas.android.com/apk/res/android"
+		xmlns:tools="http://schemas.android.com/tools"
+		xmlns:app="http://schemas.android.com/apk/res-auto">
+
+	<data>
+		<variable
+				name="viewModel"
+				type="com.hyman.newsapp.views.NewsViewModel"/>
+	</data>
+
+	<androidx.constraintlayout.widget.ConstraintLayout
+			android:layout_width="match_parent"
+			android:layout_height="match_parent"
+			android:padding="16dp">
+
+		<androidx.recyclerview.widget.RecyclerView
+				android:id="@+id/rv_contact_list"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				app:isVisible="@{viewModel.hasContacts}"
+				tools:listitem="@layout/contact_list_item"
+				app:layout_constraintBottom_toBottomOf="parent"
+				app:layout_constraintEnd_toEndOf="parent"
+				app:layout_constraintStart_toStartOf="parent"
+				app:layout_constraintTop_toTopOf="parent"/>
+
+		<TextView
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				android:fontFamily="sans-serif-black"
+				android:textSize="18sp"
+				android:text="@string/no_contacts"
+				app:isVisible="@{!viewModel.hasContacts}"
+				app:layout_constraintBottom_toBottomOf="parent"
+				app:layout_constraintEnd_toEndOf="parent"
+				app:layout_constraintStart_toStartOf="parent"
+				app:layout_constraintTop_toTopOf="parent"/>
+
+	</androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -4,4 +4,5 @@
 	<color name="colorPrimaryDark">#00574B</color>
 	<color name="colorAccent">#D81B60</color>
 	<color name="custom_gray_text">#4a4a4a</color>
+	<color name="contact_item_bg_color">#2D9B9B9B</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,11 +1,15 @@
 <resources>
-    <string name="app_name">NewsApp</string>
-    <string name="title_activity_news">NewsActivity</string>
-    <string name="title_home">Home</string>
-    <string name="title_food">Food</string>
-    <string name="title_travel">Travel</string>
+	<string name="app_name">NewsApp</string>
+	<string name="title_activity_news">NewsActivity</string>
+	<string name="title_home">Home</string>
+	<string name="title_food">Food</string>
+	<string name="title_travel">Travel</string>
 	<string name="no_network_connection">No Internet Connection</string>
 	<string name="retry">RETRY</string>
 	<string name="formattedDate">%s %s %s</string>
 	<string name="read_more">Read More</string>
+	<string name="title_contact">Phone Contacts</string>
+	<string name="no_contacts">You have no contacts available</string>
+	<string name="no_browser_installed">Please install a web browser application to read more</string>
+	<string name="share_intent_type">text/plain</string>
 </resources>


### PR DESCRIPTION
### What does this PR do?
- Allows users to share news with their contacts
- Allows users to be able to see full details of news from a web browser

### Description of Task to be completed?
- [x] add a contact model, adapter and dialog fragment class
- [x] setup android content provider to get user's contacts
- [x] add contact layout files with data binding setup
- [x] add a method to open news URL in when the  button is clicked

### How should this be manually tested?
```
- Clone this repo
- Open and build the project on an android studio
- Launch the application
- From any of the pages, click on the `share` icon to access your contacts
- Then select a contact to share the news with
- Click on the `Read More` button to open news in a browser in order to view more about the news
```
Any background context you want to provide?
Nil
### What are the relevant pivotal tracker stories?
story type: feature
story Id: 164192776
story titles: User can share news content to their contacts

### Screenshots (if appropriate)
![share](https://user-images.githubusercontent.com/22524619/53636533-d9ab1a00-3c20-11e9-9711-e8cff7630759.gif)

